### PR TITLE
Correct i18n README's 'Building Locally'

### DIFF
--- a/internationalization/README.md
+++ b/internationalization/README.md
@@ -15,7 +15,7 @@ Run the following commands:
 
 ```bash
 git clone https://github.com/elm-community/js-integration-examples.git
-cd js-integration-examples/websockets
+cd js-integration-examples/internationalization
 
 elm make src/Main.elm --output=elm.js
 open index.html


### PR DESCRIPTION
Replace reference to 'websocket' directory with 'internationalization'
directory.